### PR TITLE
Fix page structure: move Services section inside container and clean up layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,30 +325,36 @@
                 </div>
             </section>
             <hr class="m-0" />
+            <!-- Professional Services-->
+            <section class="resume-section" id="services">
+                <div class="resume-section-content font_palatino">
+                    <h3 class="mb-3 font_palatino">Professional Services and Activities</h3>
+                    <ul>
+                        <li><b>Program Committee:</b> HPCA'2026, NSDI'2025, HPCA'2025, MICRO'2024 (ERC), ISCA'2024 (ERC and industry track committee), HPCA'2024, HPCA'2023 (ERC), EuroSys'2022 (shadow PC)</li>
+                        <li><b>Reviewer:</b> IEEE Transactions on Parallel and Distributed Systems (TPDS, 2022), IEEE Computer Architecture Letter (CAL, 2022–2023), ACM Transactions on Architecture and Code Optimization (TACO, 2024)</li>
+                    </ul>
+                </div>
+            </section>
         </div>
-        <!-- Professional Services-->
-        <section class="resume-section" id="services">
-            <div class="resume-section-content font_palatino">
-                <h3 class="mb-3 font_palatino">Professional Services and Activities</h3>
-                <ul>
-                    <li><b>Program Committee: HPCA'2026, NSDI’2025, HPCA’2025, MICRO’2024 (ERC), ISCA’2024 (ERC and industry track committee), HPCA’2024, HPCA’2023 (ERC), EuroSys’2022 (shadow PC)</li>
-                    <li><b>Reviewer:</b> IEEE Transactions on Parallel and Distributed Systems (TPDS, 2022), IEEE Computer Architecture Letter (CAL, 20222023), ACM Transactions on Architecture and Code Optimization (TACO, 2024)</li>
-                </ul>
-            </div>
-        </section>
 
-        <script type="text/javascript" id="clustrmaps" src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=200&t=n&d=zIqtdsu1r7tkmoW-xJcgXdfGBDQirskYDT15fjS7ZTA"></script> <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Z2VN5LL3G"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-4Z2VN5LL3G'); </script>
+        <!-- Analytics -->
+        <script type="text/javascript" id="clustrmaps" src="//cdn.clustrmaps.com/map_v2.js?cl=ffffff&w=200&t=n&d=zIqtdsu1r7tkmoW-xJcgXdfGBDQirskYDT15fjS7ZTA"></script>
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Z2VN5LL3G"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-4Z2VN5LL3G');
+        </script>
 
-        <hr class="m-0" />
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
 
-        <footer class="footer" style="text-align: center;">
-            Adapted from <a href="https://github.com/StartBootstrap/startbootstrap-resume" target="_blank" style="color: black;">startbootstrap</a>
-
-            last update: 10/2025
+        <footer class="footer" style="text-align: center; padding: 1rem 0; color: #6c757d; font-size: 0.85rem;">
+            Adapted from <a href="https://github.com/StartBootstrap/startbootstrap-resume" target="_blank" style="color: #6c757d;">startbootstrap</a>
+            &middot; Last update: 10/2025
         </footer>
     </body>
 </html>


### PR DESCRIPTION
## Problem

The Professional Services section (`<section id="services">`) was placed **outside** the `<div class="container-fluid">` that wraps all other page sections. This caused it to have different padding and layout behavior compared to the About and Publications sections.

Additionally, the analytics scripts (ClustrMaps and Google Analytics) were placed inline between sections with no formatting, and the footer had minimal styling.

## Changes

1. **Moved Services section inside `container-fluid`**: The closing `</div>` for `container-fluid` now comes after the Services section, ensuring consistent layout with the rest of the page.

2. **Reorganized analytics scripts**: Separated ClustrMaps and Google Analytics into properly formatted, readable script blocks with a comment header.

3. **Improved footer styling**: Added muted text color (`#6c757d`), proper padding, smaller font size, and a middot separator between the attribution and last-update date.

## Before vs After

| Element | Before | After |
|---------|--------|-------|
| Services section | Outside `container-fluid` | Inside `container-fluid` |
| Analytics scripts | Single minified line | Properly formatted blocks |
| Footer | Plain black text, no padding | Muted gray, padded, 0.85rem font |